### PR TITLE
Add withCredentials property if already defined

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -443,14 +443,27 @@ function MockHttpServer (handler) {
 };
 MockHttpServer.prototype = {
 
+    getProperties: function () {
+        var xhr = new XMLHttpRequest();
+        return {
+          withCredentials: xhr.withCredentials
+        }
+    },
+
     start: function () {
         var self = this;
+
+        var props = this.getProperties();
 
         function Request () {
             this.onsend = function () {
                 self.handle(this);
             };
             MockHttpRequest.apply(this, arguments);
+
+            for(var i in props) {
+              this[i] = props[i];
+            }
         }
         Request.prototype = MockHttpRequest.prototype;
 


### PR DESCRIPTION
This is needed to test with CORS requests.
